### PR TITLE
feat(adaptor): implement Gmail adaptor on Google API

### DIFF
--- a/loom/adaptor/gmail.py
+++ b/loom/adaptor/gmail.py
@@ -1,29 +1,398 @@
-"""Gmail adaptor — IMAP / Google API."""
+"""Gmail adaptor — Google API REST + OAuth2.
+
+Polls Gmail for new messages matching a query, normalises them into
+``Envelope`` objects, and delivers them to the ``Mailbox``. Approved
+actions supported: ``reply`` / ``archive`` / ``label`` / ``trash``.
+"""
 
 from __future__ import annotations
 
-from typing import Any
+import base64
+import json
+import logging
+from collections import deque
+from collections.abc import Iterable
+from datetime import datetime
+from email.message import EmailMessage
+from email.utils import parseaddr
+from pathlib import Path
+from typing import Any, TypedDict, cast
+
+import anyio
+from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore[import-untyped]
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore[import-untyped]
+from googleapiclient.discovery import build  # type: ignore[import-untyped]
+from googleapiclient.errors import HttpError  # type: ignore[import-untyped]
 
 from loom.adaptor.base import BaseAdaptor
 from loom.core.envelope import Envelope
+from loom.core.mailbox import Mailbox
+
+logger = logging.getLogger(__name__)
+
+
+SCOPES: list[str] = ["https://www.googleapis.com/auth/gmail.modify"]
+DEFAULT_QUERY = "is:unread -in:chats newer_than:1d"
+DEFAULT_POLL_SECONDS = 30
+SEEN_SET_MAX = 1000
+
+_CREDENTIALS_DIR = Path.home() / ".loom" / "credentials"
+DEFAULT_TOKEN_PATH = _CREDENTIALS_DIR / "gmail-token.json"
+DEFAULT_STATE_PATH = _CREDENTIALS_DIR / "gmail-state.json"
+
+
+# Typed views over the bits of Google's JSON we touch. The Gmail API returns
+# plenty more fields; only model what we read so mypy keeps us honest.
+
+
+class GmailHeader(TypedDict):
+    name: str
+    value: str
+
+
+class GmailPayload(TypedDict, total=False):
+    mimeType: str
+    headers: list[GmailHeader]
+    body: dict[str, Any]
+    parts: list[dict[str, Any]]
+    filename: str
+
+
+class GmailMessage(TypedDict, total=False):
+    id: str
+    threadId: str
+    labelIds: list[str]
+    snippet: str
+    internalDate: str
+    payload: GmailPayload
+
+
+# --- module-level helpers -----------------------------------------------------
+
+
+def _extract_header(headers: list[GmailHeader], name: str) -> str:
+    target = name.lower()
+    for h in headers:
+        if h.get("name", "").lower() == target:
+            return h.get("value", "")
+    return ""
+
+
+def _walk_parts(part: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    yield part
+    for sub in part.get("parts") or []:
+        yield from _walk_parts(sub)
+
+
+def _decode_body(payload: dict[str, Any]) -> str:
+    """Return the most-text-friendly body we can find; prefer text/plain."""
+    plain = ""
+    html = ""
+    for part in _walk_parts(payload):
+        mime = part.get("mimeType", "")
+        body = part.get("body") or {}
+        data = body.get("data")
+        if not data:
+            continue
+        try:
+            decoded = base64.urlsafe_b64decode(data.encode("ascii")).decode(
+                "utf-8", errors="replace"
+            )
+        except (ValueError, UnicodeDecodeError):
+            continue
+        if mime == "text/plain" and not plain:
+            plain = decoded
+        elif mime == "text/html" and not html:
+            html = decoded
+    return plain or html
+
+
+def _load_credentials(client_secrets: Path, token_path: Path) -> Any:
+    """Run InstalledAppFlow on first call, refresh thereafter."""
+    creds: Any = None
+    if token_path.exists():
+        creds = Credentials.from_authorized_user_file(  # type: ignore[no-untyped-call]
+            str(token_path), SCOPES
+        )
+    if creds is not None and creds.valid:
+        return creds
+    if creds is not None and creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+    else:
+        flow = InstalledAppFlow.from_client_secrets_file(str(client_secrets), SCOPES)
+        creds = flow.run_local_server(port=0)
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.write_text(cast(str, creds.to_json()))
+    return creds
+
+
+# --- adaptor ------------------------------------------------------------------
 
 
 class GmailAdaptor(BaseAdaptor):
-    """Watches Gmail inbox via IMAP IDLE or Google Pub/Sub push."""
+    """Polls Gmail via the Google API and emits Envelopes into a Mailbox."""
 
     name = "gmail"
 
+    def __init__(
+        self,
+        mailbox: Mailbox,
+        client_secrets_path: Path,
+        token_path: Path | None = None,
+        state_path: Path | None = None,
+        query: str = DEFAULT_QUERY,
+        poll_seconds: int = DEFAULT_POLL_SECONDS,
+        user_id: str = "me",
+    ) -> None:
+        self._mailbox = mailbox
+        self._client_secrets = client_secrets_path
+        self._token_path = token_path or DEFAULT_TOKEN_PATH
+        self._state_path = state_path or DEFAULT_STATE_PATH
+        self._query = query
+        self._poll_seconds = poll_seconds
+        self._user_id = user_id
+
+        self._service: Any = None
+        self._scheduler: AsyncIOScheduler | None = None
+        self._seen: deque[str] = deque(maxlen=SEEN_SET_MAX)
+        self._seen_index: set[str] = set()
+        self._running = False
+
+    # ---- lifecycle -------------------------------------------------------
+
     async def start(self) -> None:
-        # TODO: Authenticate and start watching
-        pass
+        """Authenticate, build the Gmail service, and schedule the poll loop."""
+        creds = await anyio.to_thread.run_sync(
+            _load_credentials, self._client_secrets, self._token_path
+        )
+        self._service = await anyio.to_thread.run_sync(
+            lambda: build("gmail", "v1", credentials=creds, cache_discovery=False)
+        )
+        self._load_seen()
+
+        self._scheduler = AsyncIOScheduler()
+        self._scheduler.add_job(
+            self._poll_once,
+            "interval",
+            seconds=self._poll_seconds,
+            max_instances=1,
+            coalesce=True,
+        )
+        self._scheduler.start()
+        self._running = True
+        logger.info("GmailAdaptor started — polling every %ds", self._poll_seconds)
 
     async def stop(self) -> None:
-        pass
+        """Stop the scheduler and drop the API client."""
+        if self._scheduler is not None:
+            self._scheduler.shutdown(wait=False)
+            self._scheduler = None
+        self._service = None
+        self._running = False
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    # ---- polling ---------------------------------------------------------
+
+    async def _poll_once(self) -> None:
+        if self._service is None:
+            return
+        try:
+            listing = await anyio.to_thread.run_sync(self._list_message_ids)
+        except HttpError as exc:
+            logger.error("Gmail list failed: %s", exc)
+            return
+
+        new_ids = [mid for mid in listing if mid not in self._seen_index]
+        if not new_ids:
+            return
+
+        for mid in new_ids:
+            try:
+                raw = await anyio.to_thread.run_sync(self._fetch_message, mid)
+                envelope = await self.normalize(raw)
+                await self._mailbox.receive(envelope)
+                self._record_seen(mid)
+            except Exception:
+                logger.exception("Failed to ingest gmail message %s", mid)
+        self._save_seen()
+
+    def _list_message_ids(self) -> list[str]:
+        resp = (
+            self._service.users()
+            .messages()
+            .list(userId=self._user_id, q=self._query)
+            .execute()
+        )
+        out: list[str] = []
+        for entry in resp.get("messages") or []:
+            mid = entry.get("id")
+            if isinstance(mid, str):
+                out.append(mid)
+        return out
+
+    def _fetch_message(self, message_id: str) -> GmailMessage:
+        msg = (
+            self._service.users()
+            .messages()
+            .get(userId=self._user_id, id=message_id, format="full")
+            .execute()
+        )
+        return cast(GmailMessage, msg)
+
+    # ---- normalization ---------------------------------------------------
 
     async def normalize(self, raw_event: Any) -> Envelope:
-        # TODO: Parse email message → Envelope
-        return Envelope(source=self.name)
+        """Convert a Gmail message dict into an ``Envelope``."""
+        msg = cast(GmailMessage, raw_event)
+        payload = cast(dict[str, Any], msg.get("payload", {}) or {})
+        headers = cast(list[GmailHeader], payload.get("headers", []) or [])
 
-    async def execute_action(self, envelope: Envelope, action: dict) -> None:
-        # TODO: Send reply, archive, label, etc.
-        pass
+        subject = _extract_header(headers, "Subject")
+        from_hdr = _extract_header(headers, "From")
+        to_hdr = _extract_header(headers, "To")
+        cc_hdr = _extract_header(headers, "Cc")
+        message_id_hdr = _extract_header(headers, "Message-ID")
+        in_reply_to = _extract_header(headers, "In-Reply-To")
+        references = _extract_header(headers, "References")
+
+        body = _decode_body(payload)
+
+        internal_ms_raw = msg.get("internalDate", "0") or "0"
+        try:
+            internal_ms = int(internal_ms_raw)
+        except ValueError:
+            internal_ms = 0
+        received_at = (
+            datetime.fromtimestamp(internal_ms / 1000)
+            if internal_ms
+            else datetime.utcnow()
+        )
+
+        labels = list(msg.get("labelIds") or [])
+        has_attachments = any(
+            bool(p.get("filename"))
+            for p in _walk_parts(payload)
+            if p is not payload
+        )
+
+        return Envelope(
+            source=self.name,
+            source_id=msg.get("id", ""),
+            title=subject,
+            body=body,
+            received_at=received_at,
+            labels=labels,
+            metadata={
+                "thread_id": msg.get("threadId", ""),
+                "message_id_header": message_id_hdr,
+                "from": from_hdr,
+                "to": to_hdr,
+                "cc": cc_hdr,
+                "in_reply_to": in_reply_to,
+                "references": references,
+                "snippet": msg.get("snippet", ""),
+                "has_attachments": has_attachments,
+            },
+        )
+
+    # ---- actions ---------------------------------------------------------
+
+    async def execute_action(self, envelope: Envelope, action: dict[str, Any]) -> None:
+        """Execute a user-approved action. Raises if the adaptor isn't started."""
+        if self._service is None:
+            raise RuntimeError("GmailAdaptor not started")
+        action_type = action.get("type", "")
+        if action_type == "reply":
+            await anyio.to_thread.run_sync(self._send_reply, envelope, action)
+        elif action_type == "archive":
+            await anyio.to_thread.run_sync(self._modify_labels, envelope, [], ["INBOX"])
+        elif action_type == "label":
+            add = [str(x) for x in action.get("labels") or []]
+            await anyio.to_thread.run_sync(self._modify_labels, envelope, add, [])
+        elif action_type == "trash":
+            await anyio.to_thread.run_sync(self._trash, envelope)
+        else:
+            raise ValueError(f"Unknown gmail action type: {action_type!r}")
+
+    def _send_reply(self, envelope: Envelope, action: dict[str, Any]) -> None:
+        meta = envelope.metadata
+        thread_id = str(meta.get("thread_id", ""))
+        msg_id_hdr = str(meta.get("message_id_header", ""))
+        references = str(meta.get("references", ""))
+        from_hdr = str(meta.get("from", ""))
+        to_addr = str(action.get("to") or parseaddr(from_hdr)[1])
+        if not to_addr:
+            raise ValueError("No reply recipient resolvable from envelope")
+
+        subject = envelope.title or ""
+        if subject and not subject.lower().startswith("re:"):
+            subject = f"Re: {subject}"
+
+        mime = EmailMessage()
+        mime["To"] = to_addr
+        mime["Subject"] = subject
+        if msg_id_hdr:
+            mime["In-Reply-To"] = msg_id_hdr
+            mime["References"] = (
+                f"{references} {msg_id_hdr}".strip() if references else msg_id_hdr
+            )
+        mime.set_content(str(action.get("body", "")))
+
+        raw = base64.urlsafe_b64encode(mime.as_bytes()).decode("ascii")
+        body: dict[str, Any] = {"raw": raw}
+        if thread_id:
+            body["threadId"] = thread_id
+        self._service.users().messages().send(userId=self._user_id, body=body).execute()
+
+    def _modify_labels(
+        self, envelope: Envelope, add: list[str], remove: list[str]
+    ) -> None:
+        self._service.users().messages().modify(
+            userId=self._user_id,
+            id=envelope.source_id,
+            body={"addLabelIds": add, "removeLabelIds": remove},
+        ).execute()
+
+    def _trash(self, envelope: Envelope) -> None:
+        self._service.users().messages().trash(
+            userId=self._user_id, id=envelope.source_id
+        ).execute()
+
+    # ---- seen-set persistence -------------------------------------------
+
+    def _record_seen(self, message_id: str) -> None:
+        if message_id in self._seen_index:
+            return
+        if len(self._seen) == SEEN_SET_MAX:
+            evicted = self._seen[0]
+            self._seen_index.discard(evicted)
+        self._seen.append(message_id)
+        self._seen_index.add(message_id)
+
+    def _load_seen(self) -> None:
+        if not self._state_path.exists():
+            return
+        try:
+            data = json.loads(self._state_path.read_text())
+        except (OSError, ValueError) as exc:
+            logger.warning("Failed to load gmail seen-set: %s", exc)
+            return
+        seen_raw = data.get("seen", []) if isinstance(data, dict) else []
+        if not isinstance(seen_raw, list):
+            return
+        for mid in seen_raw[-SEEN_SET_MAX:]:
+            if isinstance(mid, str):
+                self._seen.append(mid)
+                self._seen_index.add(mid)
+
+    def _save_seen(self) -> None:
+        try:
+            self._state_path.parent.mkdir(parents=True, exist_ok=True)
+            self._state_path.write_text(json.dumps({"seen": list(self._seen)}))
+        except OSError as exc:
+            logger.warning("Failed to persist gmail seen-set: %s", exc)

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -1,0 +1,484 @@
+"""Tests for ``loom.adaptor.gmail``.
+
+These tests stub out ``googleapiclient`` and OAuth entirely — no network. They
+cover the helpers (`_extract_header`, `_walk_parts`, `_decode_body`),
+`normalize`, the seen-set persistence, `_poll_once`, and `execute_action`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from loom.adaptor.gmail import (
+    SEEN_SET_MAX,
+    GmailAdaptor,
+    _decode_body,
+    _extract_header,
+    _walk_parts,
+)
+from loom.core.envelope import Envelope
+from loom.core.eventbus import EventBus
+from loom.core.mailbox import Mailbox
+from loom.state.store import Store
+
+# -- fixtures ------------------------------------------------------------------
+
+
+def _b64(text: str) -> str:
+    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii")
+
+
+def _make_payload(
+    plain: str | None = "Body text",
+    html: str | None = None,
+    headers: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    parts: list[dict[str, Any]] = []
+    if plain is not None:
+        parts.append({"mimeType": "text/plain", "body": {"data": _b64(plain)}})
+    if html is not None:
+        parts.append({"mimeType": "text/html", "body": {"data": _b64(html)}})
+    return {
+        "mimeType": "multipart/alternative",
+        "headers": headers
+        or [
+            {"name": "Subject", "value": "Hello"},
+            {"name": "From", "value": "Alice <alice@example.com>"},
+            {"name": "To", "value": "me@example.com"},
+            {"name": "Message-ID", "value": "<msg@example.com>"},
+        ],
+        "parts": parts,
+    }
+
+
+def _make_message(
+    msg_id: str = "abc",
+    thread_id: str = "thread-1",
+    *,
+    plain: str | None = "Body text",
+    html: str | None = None,
+    labels: list[str] | None = None,
+    internal_ms: int = 1_700_000_000_000,
+    headers: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": msg_id,
+        "threadId": thread_id,
+        "labelIds": labels if labels is not None else ["INBOX", "UNREAD"],
+        "snippet": "snippet text",
+        "internalDate": str(internal_ms),
+        "payload": _make_payload(plain=plain, html=html, headers=headers),
+    }
+
+
+def _build_adaptor(tmp_path: Path) -> GmailAdaptor:
+    bus = EventBus()
+    store = Store()
+    mailbox = Mailbox(store, bus)
+    return GmailAdaptor(
+        mailbox=mailbox,
+        client_secrets_path=tmp_path / "client-secrets.json",
+        token_path=tmp_path / "token.json",
+        state_path=tmp_path / "state.json",
+        poll_seconds=1,
+    )
+
+
+# -- helpers -------------------------------------------------------------------
+
+
+def test_extract_header_is_case_insensitive() -> None:
+    headers: list[dict[str, str]] = [
+        {"name": "Subject", "value": "Hi"},
+        {"name": "FROM", "value": "a@b"},
+    ]
+    assert _extract_header(headers, "subject") == "Hi"  # type: ignore[arg-type]
+    assert _extract_header(headers, "From") == "a@b"  # type: ignore[arg-type]
+
+
+def test_extract_header_missing_returns_empty() -> None:
+    assert _extract_header([], "Subject") == ""
+
+
+def test_walk_parts_recurses_through_multipart() -> None:
+    payload: dict[str, Any] = {
+        "mimeType": "multipart/mixed",
+        "parts": [
+            {"mimeType": "text/plain"},
+            {
+                "mimeType": "multipart/alternative",
+                "parts": [{"mimeType": "text/html"}],
+            },
+        ],
+    }
+    seen = list(_walk_parts(payload))
+    # root + plain + nested-multipart + html
+    assert len(seen) == 4
+    assert seen[0] is payload
+
+
+def test_decode_body_prefers_text_plain() -> None:
+    payload = _make_payload(plain="hello plain", html="<b>hello html</b>")
+    assert _decode_body(payload) == "hello plain"
+
+
+def test_decode_body_falls_back_to_html_when_plain_missing() -> None:
+    payload = _make_payload(plain=None, html="<b>only html</b>")
+    assert _decode_body(payload) == "<b>only html</b>"
+
+
+def test_decode_body_returns_empty_when_no_part_has_data() -> None:
+    payload: dict[str, Any] = {
+        "mimeType": "text/plain",
+        "body": {},
+        "parts": [],
+    }
+    assert _decode_body(payload) == ""
+
+
+def test_decode_body_handles_unicode() -> None:
+    payload = _make_payload(plain="你好，世界 🌏")
+    assert _decode_body(payload) == "你好，世界 🌏"
+
+
+# -- normalize -----------------------------------------------------------------
+
+
+async def test_normalize_basic_text_email(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    env = await ad.normalize(_make_message())
+    assert env.source == "gmail"
+    assert env.source_id == "abc"
+    assert env.title == "Hello"
+    assert env.body == "Body text"
+    assert env.labels == ["INBOX", "UNREAD"]
+    assert env.metadata["thread_id"] == "thread-1"
+    assert env.metadata["from"] == "Alice <alice@example.com>"
+    assert env.metadata["message_id_header"] == "<msg@example.com>"
+    assert env.metadata["has_attachments"] is False
+
+
+async def test_normalize_html_only(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    env = await ad.normalize(_make_message(plain=None, html="<p>html only</p>"))
+    assert env.body == "<p>html only</p>"
+
+
+async def test_normalize_detects_attachment(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    msg = _make_message()
+    msg["payload"]["parts"].append(
+        {
+            "mimeType": "application/pdf",
+            "filename": "report.pdf",
+            "body": {"size": 1234},
+        }
+    )
+    env = await ad.normalize(msg)
+    assert env.metadata["has_attachments"] is True
+
+
+async def test_normalize_invalid_internal_date_does_not_raise(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    msg = _make_message()
+    msg["internalDate"] = "not-a-number"
+    env = await ad.normalize(msg)
+    assert env.received_at is not None
+
+
+async def test_normalize_missing_optional_headers(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    msg = _make_message(headers=[{"name": "Subject", "value": "S"}])
+    env = await ad.normalize(msg)
+    assert env.title == "S"
+    assert env.metadata["from"] == ""
+    assert env.metadata["in_reply_to"] == ""
+
+
+# -- seen-set persistence ------------------------------------------------------
+
+
+def test_record_seen_dedupes(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    ad._record_seen("a")
+    ad._record_seen("a")
+    assert len(ad._seen) == 1
+    assert ad._seen_index == {"a"}
+
+
+def test_record_seen_evicts_oldest_at_max(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    overflow = 5
+    for i in range(SEEN_SET_MAX + overflow):
+        ad._record_seen(f"id-{i}")
+    assert len(ad._seen) == SEEN_SET_MAX
+    assert "id-0" not in ad._seen_index
+    assert f"id-{SEEN_SET_MAX + overflow - 1}" in ad._seen_index
+
+
+def test_load_seen_when_no_state_file(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    ad._load_seen()  # must not raise
+    assert ad._seen_index == set()
+
+
+def test_load_seen_when_corrupt_json(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    ad._state_path.parent.mkdir(parents=True, exist_ok=True)
+    ad._state_path.write_text("not valid json {")
+    ad._load_seen()
+    assert ad._seen_index == set()
+
+
+def test_save_then_load_roundtrip(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    ad._record_seen("x")
+    ad._record_seen("y")
+    ad._save_seen()
+
+    fresh = _build_adaptor(tmp_path)
+    fresh._load_seen()
+    assert fresh._seen_index == {"x", "y"}
+
+
+# -- execute_action ------------------------------------------------------------
+
+
+async def test_execute_action_raises_when_not_started(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    env = Envelope(source="gmail", source_id="x")
+    with pytest.raises(RuntimeError, match="not started"):
+        await ad.execute_action(env, {"type": "reply", "body": "hi"})
+
+
+async def test_execute_action_unknown_type(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    ad._service = MagicMock()
+    env = Envelope(source="gmail", source_id="x")
+    with pytest.raises(ValueError, match="Unknown gmail action type"):
+        await ad.execute_action(env, {"type": "fly_to_moon"})
+
+
+async def test_execute_action_reply_threads_correctly(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    service = MagicMock()
+    ad._service = service
+
+    env = Envelope(
+        source="gmail",
+        source_id="msg-1",
+        title="Project update",
+        metadata={
+            "thread_id": "thread-xyz",
+            "message_id_header": "<orig@example.com>",
+            "references": "<ref1@example.com>",
+            "from": "Bob <bob@example.com>",
+        },
+    )
+    await ad.execute_action(env, {"type": "reply", "body": "Hi back"})
+
+    send = service.users.return_value.messages.return_value.send
+    send.assert_called_once()
+    body = send.call_args.kwargs["body"]
+    assert body["threadId"] == "thread-xyz"
+    raw = base64.urlsafe_b64decode(body["raw"]).decode("utf-8")
+    assert "To: bob@example.com" in raw
+    assert "Subject: Re: Project update" in raw
+    assert "In-Reply-To: <orig@example.com>" in raw
+    assert "References: <ref1@example.com> <orig@example.com>" in raw
+    assert "Hi back" in raw
+
+
+async def test_execute_action_reply_does_not_double_re_prefix(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    ad._service = MagicMock()
+    env = Envelope(
+        source="gmail",
+        source_id="msg-1",
+        title="Re: Already a reply",
+        metadata={"from": "bob@example.com", "thread_id": "t"},
+    )
+    await ad.execute_action(env, {"type": "reply", "body": "ack"})
+    send = ad._service.users.return_value.messages.return_value.send
+    raw = base64.urlsafe_b64decode(send.call_args.kwargs["body"]["raw"]).decode("utf-8")
+    assert "Subject: Re: Already a reply" in raw
+    assert "Subject: Re: Re:" not in raw
+
+
+async def test_execute_action_reply_explicit_to_overrides_from(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    ad._service = MagicMock()
+    env = Envelope(
+        source="gmail",
+        source_id="msg-1",
+        metadata={"from": "noreply@example.com"},
+    )
+    await ad.execute_action(
+        env, {"type": "reply", "body": "ok", "to": "human@example.com"}
+    )
+    send = ad._service.users.return_value.messages.return_value.send
+    raw = base64.urlsafe_b64decode(send.call_args.kwargs["body"]["raw"]).decode("utf-8")
+    assert "To: human@example.com" in raw
+
+
+async def test_execute_action_archive_removes_inbox_label(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    service = MagicMock()
+    ad._service = service
+    env = Envelope(source="gmail", source_id="msg-1")
+    await ad.execute_action(env, {"type": "archive"})
+    service.users.return_value.messages.return_value.modify.assert_called_once_with(
+        userId="me",
+        id="msg-1",
+        body={"addLabelIds": [], "removeLabelIds": ["INBOX"]},
+    )
+
+
+async def test_execute_action_label_adds_labels(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    service = MagicMock()
+    ad._service = service
+    env = Envelope(source="gmail", source_id="msg-1")
+    await ad.execute_action(
+        env, {"type": "label", "labels": ["IMPORTANT", "STARRED"]}
+    )
+    service.users.return_value.messages.return_value.modify.assert_called_once_with(
+        userId="me",
+        id="msg-1",
+        body={"addLabelIds": ["IMPORTANT", "STARRED"], "removeLabelIds": []},
+    )
+
+
+async def test_execute_action_trash(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    service = MagicMock()
+    ad._service = service
+    env = Envelope(source="gmail", source_id="msg-1")
+    await ad.execute_action(env, {"type": "trash"})
+    service.users.return_value.messages.return_value.trash.assert_called_once_with(
+        userId="me", id="msg-1"
+    )
+
+
+# -- _poll_once ---------------------------------------------------------------
+
+
+async def test_poll_ingests_new_messages_and_records_seen(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    received: list[Envelope] = []
+
+    async def capture(_event: str, env: object) -> None:
+        if isinstance(env, Envelope):
+            received.append(env)
+
+    ad._mailbox._bus.subscribe("new_envelope", capture)
+
+    service = MagicMock()
+    service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+        "messages": [{"id": "a"}, {"id": "b"}],
+    }
+    fetched = {"a": _make_message("a"), "b": _make_message("b")}
+
+    def get_call(*, userId: str, id: str, format: str) -> Any:  # noqa: N803 (real Gmail API param)
+        del userId, format
+        m = MagicMock()
+        m.execute.return_value = fetched[id]
+        return m
+
+    service.users.return_value.messages.return_value.get.side_effect = get_call
+    ad._service = service
+
+    await ad._poll_once()
+    # Let bus.publish's create_task callbacks run.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert {e.source_id for e in received} == {"a", "b"}
+    assert {"a", "b"} <= ad._seen_index
+
+
+async def test_poll_skips_already_seen(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    ad._record_seen("a")
+
+    received: list[Envelope] = []
+
+    async def capture(_event: str, env: object) -> None:
+        if isinstance(env, Envelope):
+            received.append(env)
+
+    ad._mailbox._bus.subscribe("new_envelope", capture)
+
+    service = MagicMock()
+    service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+        "messages": [{"id": "a"}],
+    }
+    ad._service = service
+
+    await ad._poll_once()
+    await asyncio.sleep(0)
+
+    assert received == []
+    assert not service.users.return_value.messages.return_value.get.called
+
+
+async def test_poll_swallows_http_error_on_list(tmp_path: Path) -> None:
+    from googleapiclient.errors import HttpError  # type: ignore[import-untyped]
+
+    ad = _build_adaptor(tmp_path)
+    service = MagicMock()
+    service.users.return_value.messages.return_value.list.return_value.execute.side_effect = (
+        HttpError(resp=MagicMock(status=500, reason="oops"), content=b"server err")
+    )
+    ad._service = service
+
+    # Must not raise — adaptor logs and waits for next poll.
+    await ad._poll_once()
+
+
+async def test_poll_continues_when_one_message_fails(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    received: list[Envelope] = []
+
+    async def capture(_event: str, env: object) -> None:
+        if isinstance(env, Envelope):
+            received.append(env)
+
+    ad._mailbox._bus.subscribe("new_envelope", capture)
+
+    service = MagicMock()
+    service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+        "messages": [{"id": "bad"}, {"id": "good"}],
+    }
+
+    def get_call(*, userId: str, id: str, format: str) -> Any:  # noqa: N803 (real Gmail API param)
+        del userId, format
+        m = MagicMock()
+        if id == "bad":
+            m.execute.side_effect = RuntimeError("bad message")
+        else:
+            m.execute.return_value = _make_message("good")
+        return m
+
+    service.users.return_value.messages.return_value.get.side_effect = get_call
+    ad._service = service
+
+    await ad._poll_once()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert {e.source_id for e in received} == {"good"}
+    assert "good" in ad._seen_index
+    assert "bad" not in ad._seen_index
+
+
+async def test_poll_does_nothing_when_service_unset(tmp_path: Path) -> None:
+    ad = _build_adaptor(tmp_path)
+    # _service is None until start() runs — should be a no-op.
+    await ad._poll_once()


### PR DESCRIPTION
## Summary
Implements the Gmail adaptor as one of the four first-class sources in Loom. Uses Google API REST + OAuth2 to poll for new messages, normalize them into `Envelope` objects, and deliver to the `Mailbox`.

## Features
- **OAuth2 flow**: Desktop app flow via `google_auth_oauthlib`
- **Polling**: `AsyncIOScheduler` polls every 30s (configurable) for unread messages
- **Normalization**: Converts Gmail messages to `Envelope` with proper metadata (thread_id, headers, attachments, labels)
- **Actions**: `reply` (thread-aware), `archive`, `label`, `trash`
- **Deduplication**: Persistent seen-set (`~/.loom/credentials/gmail-state.json`, max 1000 entries)
- **Error handling**: Graceful degradation on individual message failures

## Test plan
- [x] 30 unit tests covering helpers, normalize, seen-set, actions, _poll_once
- [x] mypy --strict passes
- [x] ruff check passes
- [x] E2E verified locally: OAuth → polling → envelope → reply → dedupe

## Usage notes
Users need:
1. `uv sync --extra gmail`
2. OAuth client secrets at `~/.loom/credentials/gmail-client-secrets.json`
3. Clash TUN mode enabled for China network environment (system proxy incompatible with httplib2)