### PR TITLE
feat(webui): toggle detail panel by re-clicking the active card

### DIFF
--- a/loom/webui/frontend/src/components/Column.tsx
+++ b/loom/webui/frontend/src/components/Column.tsx
@@ -8,7 +8,7 @@ interface ColumnProps {
   status: EnvelopeStatus
   envelopes: Envelope[]
   selectedId: string | null
-  onSelect: (id: string) => void
+  onSelect: (id: string | null) => void
 }
 
 const STATUS_TOKEN: Record<EnvelopeStatus, { bg: string; dot: string; label: string }> = {
@@ -66,7 +66,7 @@ export function Column({ title, status, envelopes, selectedId, onSelect }: Colum
                 <EnvelopeCard
                   envelope={e}
                   active={e.id === selectedId}
-                  onClick={() => onSelect(e.id)}
+                  onClick={() => onSelect(e.id === selectedId ? null : e.id)}
                 />
               </li>
             ))}

--- a/loom/webui/frontend/src/components/KanbanBoard.tsx
+++ b/loom/webui/frontend/src/components/KanbanBoard.tsx
@@ -16,7 +16,7 @@ interface KanbanBoardProps {
   envelopes: Envelope[]
   showArchived: boolean
   selectedId: string | null
-  onSelect: (id: string) => void
+  onSelect: (id: string | null) => void
   onCloseDetail: () => void
 }
 


### PR DESCRIPTION
## Summary
- Clicking an already-selected envelope card now closes the detail panel instead of keeping it open
- Widens `onSelect` prop type from `(id: string)` to `(id: string | null)` in `Column` and `KanbanBoard`

## Test plan
- [ ] Click an envelope card → detail panel opens
- [ ] Click the same card again → detail panel closes
- [ ] Click a different card while one is open → switches to new card's detail
- [ ] X button still closes the panel as before