### PR TITLE
fix(webui): smooth kanban detail panel animation and column alignment

### DIFF
--- a/loom/webui/frontend/package-lock.json
+++ b/loom/webui/frontend/package-lock.json
@@ -86,7 +86,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -508,7 +507,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
       "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -2290,7 +2288,6 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2306,7 +2303,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2318,7 +2314,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2556,7 +2551,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3239,7 +3233,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4367,7 +4360,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4540,7 +4532,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4553,7 +4544,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4989,7 +4979,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -5090,7 +5079,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5364,7 +5352,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/loom/webui/frontend/src/App.tsx
+++ b/loom/webui/frontend/src/App.tsx
@@ -33,23 +33,26 @@ export default function App() {
     <div className="flex h-screen bg-background text-foreground">
       <Sidebar
         view={view}
-        onViewChange={setView}
+        onViewChange={(v) => { setSelectedId(null); setView(v) }}
         sourceFilter={sourceFilter}
         groupFilter={groupFilter}
         sourceIdPrefix={sourceIdPrefix}
         onSourceFilter={(src) => {
+          setSelectedId(null)
           setSourceFilter(src)
           setGroupFilter(null)
           setSourceIdPrefix(null)
           setView("inbox")
         }}
         onGroupFilter={(grp) => {
+          setSelectedId(null)
           setGroupFilter(grp)
           setSourceFilter(null)
           setSourceIdPrefix(null)
           setView("inbox")
         }}
         onSourceIdPrefix={(prefix) => {
+          setSelectedId(null)
           setSourceIdPrefix(prefix)
           setSourceFilter(null)
           setGroupFilter(null)

--- a/loom/webui/frontend/src/components/EnvelopeCard.tsx
+++ b/loom/webui/frontend/src/components/EnvelopeCard.tsx
@@ -17,6 +17,7 @@ function pickLabelColors(env: Envelope): Record<string, string> {
 
 /** Compact card shown inside a Kanban column. */
 export function EnvelopeCard({ envelope, active, onClick }: EnvelopeCardProps) {
+  const md = envelope.metadata as Record<string, unknown> | undefined
   const colors = pickLabelColors(envelope)
   // Don't render the synthetic state/kind labels the adaptor appended ("pr", "issue", "open", "closed").
   const displayLabels = envelope.labels.filter(
@@ -51,7 +52,7 @@ export function EnvelopeCard({ envelope, active, onClick }: EnvelopeCardProps) {
           )}
         </div>
         <span className="shrink-0 text-xs text-muted-foreground">
-          {envelope.received_at ? formatRelativeTime(envelope.received_at) : "—"}
+          {formatRelativeTime(((md?.created_at as string) || envelope.received_at) || "") || "—"}
         </span>
       </div>
       <div className="mt-1 line-clamp-2 text-sm font-medium leading-snug text-foreground">

--- a/loom/webui/frontend/src/components/EnvelopeCard.tsx
+++ b/loom/webui/frontend/src/components/EnvelopeCard.tsx
@@ -52,7 +52,7 @@ export function EnvelopeCard({ envelope, active, onClick }: EnvelopeCardProps) {
           )}
         </div>
         <span className="shrink-0 text-xs text-muted-foreground">
-          {formatRelativeTime(((md?.created_at as string) || envelope.received_at) || "") || "—"}
+          {formatRelativeTime(((md?.created_at as string) || envelope.received_at || "")) || "—"}
         </span>
       </div>
       <div className="mt-1 line-clamp-2 text-sm font-medium leading-snug text-foreground">

--- a/loom/webui/frontend/src/components/KanbanBoard.tsx
+++ b/loom/webui/frontend/src/components/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 
 import type { Envelope, EnvelopeStatus } from "@/lib/types"
 import { cn } from "@/lib/utils"
@@ -11,6 +11,10 @@ const COLUMN_DEFS = [
   { title: "In Review", status: "in_review" as const },
   { title: "Done", status: "done" as const },
 ] as const
+
+const ANIM_MS = 300
+const PAD = 16 // container px-4
+const GAP = 12
 
 interface KanbanBoardProps {
   envelopes: Envelope[]
@@ -44,28 +48,104 @@ export function KanbanBoard({
     ? [...grouped.done, ...grouped.dismissed, ...grouped.failed]
     : grouped.done
 
-  // Freeze the active column status when a card is first selected so that
-  // envelope status changes (via polling) don't cause layout jumps.
-  const [frozenStatus, setFrozenStatus] = useState<EnvelopeStatus | null>(null)
+  const isOpen = selectedId !== null
 
-  useEffect(() => {
-    if (selectedId) {
-      const env = envelopes.find((e) => e.id === selectedId)
-      if (env) setFrozenStatus(env.status)
-    } else {
-      setFrozenStatus(null)
-    }
+  const activeStatus = useMemo(() => {
+    if (!selectedId) return null
+    const s = envelopes.find((e) => e.id === selectedId)?.status ?? null
+    if (s === "dismissed" || s === "failed") return "done" as const
+    return s
   }, [selectedId, envelopes])
 
-  const isOpen = selectedId !== null
-  const activeStatus = isOpen ? frozenStatus : null
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const colRefs = useRef<Partial<Record<string, HTMLDivElement | null>>>({})
+  // Captured before the DOM update so panel starts at the column's true right edge.
+  const pendingPanelLeftRef = useRef<number | null>(null)
 
-  const orderedColumns = useMemo(() => {
-    if (!activeStatus) return COLUMN_DEFS
-    const active = COLUMN_DEFS.find((c) => c.status === activeStatus)!
-    const rest = COLUMN_DEFS.filter((c) => c.status !== activeStatus)
-    return [active, ...rest]
-  }, [activeStatus])
+  const [frozenStatus, setFrozenStatus] = useState<string | null>(null)
+  const [frozenWidth, setFrozenWidth] = useState<number | null>(null)
+  const [panelLeft, setPanelLeft] = useState<number | null>(null)
+  // Suppresses column transitions for one frame on close.
+  const [isSnapping, setIsSnapping] = useState(false)
+  // Suppresses the panel's left transition while it snaps to its start position.
+  const [isPanelSnapping, setIsPanelSnapping] = useState(false)
+
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const animRaf = useRef<number | null>(null)
+
+  useLayoutEffect(() => {
+    if (closeTimer.current) clearTimeout(closeTimer.current)
+    if (animRaf.current) cancelAnimationFrame(animRaf.current)
+
+    if (selectedId) {
+      const env = envelopes.find((e) => e.id === selectedId)
+      if (env && containerRef.current) {
+        const mapped =
+          env.status === "dismissed" || env.status === "failed" ? "done" : env.status
+        const colEl = colRefs.current[mapped]
+        if (colEl) {
+          const cRect = containerRef.current.getBoundingClientRect()
+          const colWidth = Math.round((cRect.width - 2 * PAD) / 4)
+          const finalPanelLeft = PAD + colWidth + GAP
+
+          setIsSnapping(false)
+          setFrozenStatus(mapped)
+          setFrozenWidth(colWidth)
+
+          const initialPanelLeft = pendingPanelLeftRef.current ?? finalPanelLeft
+
+          if (initialPanelLeft !== finalPanelLeft) {
+            // Panel snaps instantly to the column's original right edge (no
+            // left transition), then animates left in sync with the columns.
+            setIsPanelSnapping(true)
+            setPanelLeft(initialPanelLeft)
+            animRaf.current = requestAnimationFrame(() => {
+              setIsPanelSnapping(false)
+              setPanelLeft(finalPanelLeft)
+            })
+          } else {
+            setIsPanelSnapping(false)
+            setPanelLeft(finalPanelLeft)
+          }
+        }
+      }
+    } else {
+      // Snap columns back instantly (covered by the still-opaque panel).
+      setIsSnapping(true)
+      setFrozenStatus(null)
+      setFrozenWidth(null)
+      animRaf.current = requestAnimationFrame(() => setIsSnapping(false))
+      closeTimer.current = setTimeout(() => setPanelLeft(null), ANIM_MS)
+    }
+  }, [selectedId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current)
+    if (animRaf.current) cancelAnimationFrame(animRaf.current)
+  }, [])
+
+  const effectiveStatus = frozenStatus ?? activeStatus
+
+  // handleSelect captures the column's current right edge BEFORE the DOM
+  // update so the panel can start adjacent to the column's original position.
+  const handleSelect = (id: string | null) => {
+    if (id && containerRef.current) {
+      const env = envelopes.find((e) => e.id === id)
+      if (env) {
+        const mapped =
+          env.status === "dismissed" || env.status === "failed" ? "done" : env.status
+        const colEl = colRefs.current[mapped]
+        if (colEl) {
+          const cRect = containerRef.current.getBoundingClientRect()
+          const eRect = colEl.getBoundingClientRect()
+          pendingPanelLeftRef.current = Math.round(eRect.right - cRect.left) + GAP
+        }
+      }
+    } else {
+      pendingPanelLeftRef.current = null
+    }
+    onSelect(id)
+  }
 
   const columnData = useMemo(
     () => ({
@@ -78,26 +158,32 @@ export function KanbanBoard({
   )
 
   return (
-    <div className="flex h-full px-4 py-3">
-      {orderedColumns.map((colDef, idx) => {
-        const isHidden = isOpen && idx > 0
+    <div ref={containerRef} className="relative flex h-full overflow-hidden px-4 py-3">
+      {COLUMN_DEFS.map((colDef) => {
+        const isActive = effectiveStatus === colDef.status && frozenWidth != null
+        const isHidden = isOpen && effectiveStatus != null && effectiveStatus !== colDef.status
         return (
           <div
             key={colDef.status}
+            ref={(el) => { colRefs.current[colDef.status] = el }}
             className={cn(
-              "transition-all duration-300 ease-in-out",
-              isHidden
-                ? "w-0 min-w-0 flex-none overflow-hidden opacity-0"
-                : "flex h-full min-w-[260px] flex-1 flex-col rounded-lg p-2"
+              "flex-none h-full flex-col overflow-hidden rounded-lg p-2",
+              isHidden && "opacity-0 pointer-events-none select-none",
             )}
-            style={isHidden ? { marginLeft: 0, marginRight: 0 } : undefined}
+            style={{
+              width: isActive ? frozenWidth! : isHidden ? 0 : "25%",
+              ...(isHidden ? { padding: 0 } : {}),
+              transition: isActive || isSnapping
+                ? "none"
+                : "width 300ms ease-in-out, padding 300ms ease-in-out, opacity 300ms ease-in-out",
+            }}
           >
             <Column
               title={colDef.title}
               status={colDef.status}
               envelopes={columnData[colDef.status]}
               selectedId={selectedId}
-              onSelect={onSelect}
+              onSelect={handleSelect}
             />
           </div>
         )
@@ -105,13 +191,19 @@ export function KanbanBoard({
 
       <div
         className={cn(
-          "flex-none overflow-hidden rounded-lg border-l border-border transition-all duration-300 ease-in-out",
-          isOpen
-            ? "ml-3 min-w-[480px] flex-[3] opacity-100"
-            : "min-w-0 w-0 flex-none opacity-0"
+          "absolute inset-y-3 right-0 overflow-hidden rounded-lg border-l border-border",
+          isOpen ? "opacity-100" : "opacity-0 pointer-events-none",
         )}
+        style={{
+          left: panelLeft ?? "100%",
+          transition: isPanelSnapping
+            ? "opacity 300ms ease-in-out"
+            : "opacity 300ms ease-in-out, left 300ms ease-in-out",
+        }}
       >
-        {isOpen && <DetailPanel envelopeId={selectedId} onClose={onCloseDetail} />}
+        {(isOpen || frozenStatus != null) && (
+          <DetailPanel envelopeId={selectedId} onClose={() => handleSelect(null)} />
+        )}
       </div>
     </div>
   )

--- a/loom/webui/frontend/src/components/KanbanBoard.tsx
+++ b/loom/webui/frontend/src/components/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import type { Envelope, EnvelopeStatus } from "@/lib/types"
 import { cn } from "@/lib/utils"
@@ -47,17 +47,15 @@ export function KanbanBoard({
   // Freeze the active column status when a card is first selected so that
   // envelope status changes (via polling) don't cause layout jumps.
   const [frozenStatus, setFrozenStatus] = useState<EnvelopeStatus | null>(null)
-  const prevSelectedId = useRef<string | null>(null)
 
-  if (selectedId !== prevSelectedId.current) {
-    prevSelectedId.current = selectedId
+  useEffect(() => {
     if (selectedId) {
       const env = envelopes.find((e) => e.id === selectedId)
       if (env) setFrozenStatus(env.status)
     } else {
       setFrozenStatus(null)
     }
-  }
+  }, [selectedId, envelopes])
 
   const isOpen = selectedId !== null
   const activeStatus = isOpen ? frozenStatus : null

--- a/loom/webui/frontend/src/lib/utils.ts
+++ b/loom/webui/frontend/src/lib/utils.ts
@@ -6,7 +6,9 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function formatRelativeTime(iso: string): string {
+  if (!iso) return ""
   const date = new Date(iso)
+  if (isNaN(date.getTime())) return ""
   const diffMs = Date.now() - date.getTime()
   const diffMin = Math.floor(diffMs / 60000)
   if (diffMin < 1) return "just now"


### PR DESCRIPTION
## Summary

- Rewrites Kanban detail panel open/close animation: active column stays frozen at measured width, hidden columns animate only `width`+`padding`+`opacity` (no flex-grow transitions) to eliminate reflow and jitter
- Detail panel is absolutely positioned and slides in sync with the active column via `left` transition, ensuring correct alignment for all 4 columns (not just Queue)
- Fixes hidden columns contributing layout space when `width:0` due to `box-sizing: border-box` + `padding` — clears padding on hidden columns to ensure true 0px width
- `isSnapping` flag suppresses transitions on close so columns snap back invisibly under the still-opaque panel before it fades out
- Closes detail panel automatically when switching source, group, or navigation view in the sidebar